### PR TITLE
Fix XV border artifacts when using gstreamer 1.0

### DIFF
--- a/src/sunxi_disp.c
+++ b/src/sunxi_disp.c
@@ -369,10 +369,12 @@ int sunxi_layer_set_yuv420_input_buffer(sunxi_disp_t *ctx,
                                         uint32_t      v_offset_in_framebuffer,
                                         int           width,
                                         int           height,
-                                        int           stride)
+                                        int           stride,
+                                        int           x_pixel_offset,
+                                        int           y_pixel_offset)
 {
     __disp_fb_t fb;
-    __disp_rect_t rect = { 0, 0, width, height };
+    __disp_rect_t rect = { x_pixel_offset, y_pixel_offset, width, height };
     uint32_t tmp[4];
     memset(&fb, 0, sizeof(fb));
 

--- a/src/sunxi_disp.h
+++ b/src/sunxi_disp.h
@@ -98,7 +98,9 @@ int sunxi_layer_set_yuv420_input_buffer(sunxi_disp_t *ctx,
                                         uint32_t      v_offset_in_framebuffer,
                                         int           width,
                                         int           height,
-                                        int           stride);
+                                        int           stride,
+                                        int           x_pixel_offset,
+                                        int           y_pixel_offset);
 
 int sunxi_layer_set_output_window(sunxi_disp_t *ctx, int x, int y, int w, int h);
 

--- a/src/sunxi_video.c
+++ b/src/sunxi_video.c
@@ -191,7 +191,7 @@ xPutImage(ScrnInfoPtr pScrn, short src_x, short src_y, short drw_x, short drw_y,
             self->colorKeyEnabled = TRUE;
         }
         sunxi_layer_set_yuv420_input_buffer(disp, y_offset, u_offset, v_offset,
-                                            width, height, y_stride);
+                                            src_w, src_h, y_stride, src_x, src_y);
         sunxi_layer_set_output_window(disp, drw_x, drw_y, drw_w, drw_h);
         sunxi_layer_show(disp);
 


### PR DESCRIPTION
Since version 1.0, gstreamer (when using xvimagesink) often allocates a larger XV image for the video with padding on all four sides and then calls XvPutImage() to render a part of this image. With the current XV implementation in sunxifb this results in artifacts on the borders of the image, with a green bar at the bottom.

I am observing this when playing a 1280x720 video on a 1920x1080 screen at 32bpp, the size of the video window doesn't matter.

This problem seems to be an exaggeration of the one described in https://bugzilla.gnome.org/show_bug.cgi?id=685305.

The solution appears to be to use the source area dimensions as requested in the XvPutImage() call, as opposed to the dimensions of the originally allocated image, and to honour the offsets (src_x, src_y) when setting the source region on the display controller. With this relatively simple change, the problem seems to go away, and gstreamer 1.0 (which is faster than gstreamer 0.10 due to a zero-copy strategy) provides an acceptable solution for video playback
(with NEON-optimized ffmpeg/libav being used for decoding).

Note : I am using a command line like

```
gst-launch-1.0 filesrc location=movie.mp4 ! decodebin ! xvimagesink
```

There are several media players for gstreamer, with some of them being ported from gstreamer 0.1 to gstreamer 1.0, but most have shortcomings such as using unnecesssary buffering or unnecessary intermediate processing elements that should be optimized away.

I have only tested the patch with a few gstreamer media players and with vlc, so it might need some more testing on diverse applications using xv.
