### PR TITLE
Add option to specify dri device path

### DIFF
--- a/man/fbturbo.man
+++ b/man/fbturbo.man
@@ -104,6 +104,12 @@ some improvements are possible in this area. But if you really care
 about the desktop performance, then you likely don't want to enable
 any compositing effects in your window manager anyway.
 .TP
+.BI "Option \*qDRIDevicePath\*q \*q" string \*q
+Specify path to DRI device. By default, fbturbo uses drmOpen
+to open correct device, but it may not work on sunxi devices when 
+using second screen (on /dev/fb1) and uses /dev/dri/card0 instead of
+/dev/dri/card1. Then you can specify the correct path.  Default: (null)
+.TP
 .BI "Option \*qSwapbuffersWait\*q \*q" boolean \*q
 This option controls the behavior of eglSwapBuffers calls by OpenGL ES
 applications. If enabled, the calls will try to avoid tearing by making

--- a/src/fbdev.c
+++ b/src/fbdev.c
@@ -173,6 +173,7 @@ typedef enum {
 	OPTION_USE_BS,
 	OPTION_FORCE_BS,
 	OPTION_XV_OVERLAY,
+	OPTION_DRI_PATH,
 } FBDevOpts;
 
 static const OptionInfoRec FBDevOptions[] = {
@@ -189,6 +190,7 @@ static const OptionInfoRec FBDevOptions[] = {
 	{ OPTION_USE_BS,	"UseBackingStore",OPTV_BOOLEAN,	{0},	FALSE },
 	{ OPTION_FORCE_BS,	"ForceBackingStore",OPTV_BOOLEAN,{0},	FALSE },
 	{ OPTION_XV_OVERLAY,	"XVHWOverlay",	OPTV_BOOLEAN,	{0},	FALSE },
+	{ OPTION_DRI_PATH,	"DRIDevicePath",OPTV_STRING,	{0},	FALSE },
 	{ -1,			NULL,		OPTV_NONE,	{0},	FALSE }
 };
 
@@ -1075,7 +1077,8 @@ FBDevScreenInit(SCREEN_INIT_ARGS_DECL)
 
 	    fPtr->SunxiMaliDRI2_private = SunxiMaliDRI2_Init(pScreen,
 		xf86ReturnOptValBool(fPtr->Options, OPTION_DRI2_OVERLAY, TRUE),
-		xf86ReturnOptValBool(fPtr->Options, OPTION_SWAPBUFFERS_WAIT, TRUE));
+		xf86ReturnOptValBool(fPtr->Options, OPTION_SWAPBUFFERS_WAIT, TRUE),
+		xf86GetOptValString(fPtr->Options, OPTION_DRI_PATH));
 
 	    if (fPtr->SunxiMaliDRI2_private) {
 		xf86DrvMsg(pScrn->scrnIndex, X_INFO,

--- a/src/sunxi_mali_ump_dri2.c
+++ b/src/sunxi_mali_ump_dri2.c
@@ -33,6 +33,7 @@
 #include <ump/ump_ref_drv.h>
 
 #include <sys/ioctl.h>
+#include <fcntl.h>
 
 #include "xorgVersion.h"
 #include "xf86_OSproc.h"
@@ -1076,7 +1077,8 @@ static unsigned long ump_get_size_from_secure_id(ump_secure_id secure_id)
 
 SunxiMaliDRI2 *SunxiMaliDRI2_Init(ScreenPtr pScreen,
                                   Bool      bUseOverlay,
-                                  Bool      bSwapbuffersWait)
+                                  Bool      bSwapbuffersWait,
+                                  char     *driPath)
 {
     int drm_fd;
     DRI2InfoRec info;
@@ -1091,10 +1093,19 @@ SunxiMaliDRI2 *SunxiMaliDRI2_Init(ScreenPtr pScreen,
 
     if (!xf86LoadSubModule(xf86Screens[pScreen->myNum], "dri2"))
         return NULL;
-
-    if ((drm_fd = drmOpen("mali_drm", NULL)) < 0) {
-        ErrorF("SunxiMaliDRI2_Init: drmOpen failed!\n");
-        return NULL;
+    if(driPath)
+    {
+        if ((drm_fd = open(driPath, O_RDWR, 0)) < 0) {
+            ErrorF("SunxiMaliDRI2_Init: drmOpen failed!\n");
+            return NULL;
+        }
+    }
+    else
+    {
+        if ((drm_fd = drmOpen("mali_drm", NULL)) < 0) {
+            ErrorF("SunxiMaliDRI2_Init: drmOpen failed!\n");
+            return NULL;
+        }
     }
 
     if (ump_open() != UMP_OK) {

--- a/src/sunxi_mali_ump_dri2.h
+++ b/src/sunxi_mali_ump_dri2.h
@@ -165,7 +165,8 @@ typedef struct {
 
 SunxiMaliDRI2 *SunxiMaliDRI2_Init(ScreenPtr pScreen,
                                   Bool      bUseOverlay,
-                                  Bool      bSwapbuffersWait);
+                                  Bool      bSwapbuffersWait,
+                                  char      *driPath);
 void SunxiMaliDRI2_Close(ScreenPtr pScreen);
 
 #endif


### PR DESCRIPTION
Adds option to specify DRI device path in xorg.conf. Useful when server configured to second screen because drmOpen opens /dev/dri/card0.
If path specified, xorg prints "setversion 1.4 failed" error, but mali egl works.
