### PR TITLE
RFC: Add abstraction layer between XVideo and device drivers

### DIFF
--- a/src/interfaces.h
+++ b/src/interfaces.h
@@ -1,5 +1,6 @@
 /*
  * Copyright © 2013 Siarhei Siamashka <siarhei.siamashka@gmail.com>
+ * Copyright © 2014 Cosmin Gorgovan <cosmin [at] linux-geek [dot] org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -46,5 +47,38 @@ typedef struct {
                           int       w,
                           int       h);
 } blt2d_i;
+
+/* An interface for XVideo */
+#define XV_DOUBLEBUFFERING (1 << 0)
+
+typedef struct {
+    void *self; /* This pointer gets passed back to the functions */
+    uint32_t flags;
+    
+    int (*set_yuv420_input_buffer)(void     *self,
+                                   uint32_t  y_offset_in_framebuffer,
+                                   uint32_t  u_offset_in_framebuffer,
+                                   uint32_t  v_offset_in_framebuffer);
+    int (*set_input_par)(void *self, int w, int h, int stride, int x, int y);
+    int (*set_output_window)(void *self, int x, int y, int w, int h);
+
+    int (*show_window)(void *self);
+    int (*hide_window)(void *self);
+    
+    int (*set_colorkey)(void *self, uint32_t color);
+    int (*disable_colorkey)(void *self);
+    
+    /* optional, if NULL, memcpy is used to copy straight from the output
+       buffer of the application */
+    void (*copy_buffer)(void *self, void *dest, const void *src, size_t n);
+    
+    int (*get_screen_width)(void *self);
+    int (*get_screen_height)(void *self);
+    char *(*get_fb_mem)(void *self);
+    ssize_t (*get_visible_fb_size)(void *self);
+    ssize_t (*get_total_fb_size)(void *self);
+    
+    void (*close)(void *self);
+} xvideo_i;
 
 #endif

--- a/src/xvideo.h
+++ b/src/xvideo.h
@@ -21,10 +21,11 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef SUNXI_VIDEO_H
-#define SUNXI_VIDEO_H
+#ifndef XVIDEO_H
+#define XVIDEO_H
 
 #include "xf86xv.h"
+#include "interfaces.h"
 
 #define XV_IMAGE_MAX_WIDTH  2048
 #define XV_IMAGE_MAX_HEIGHT 2048
@@ -36,9 +37,9 @@ typedef struct {
     int                 overlay_data_offs;
     XF86VideoAdaptorPtr adapt[1];
     void               *port_privates[1];
-} SunxiVideo;
+} XVideo;
 
-SunxiVideo *SunxiVideo_Init(ScreenPtr pScreen);
-void SunxiVideo_Close(ScreenPtr pScreen);
+XVideo *XVideo_Init(ScreenPtr pScreen, xvideo_i *xv_i);
+void XVideo_Close(ScreenPtr pScreen);
 
 #endif


### PR DESCRIPTION
I have been working on adding hardware acceleration for XVideo
to another hardware platform (Rockchip RK3188). The glue code
in sunxi_video seem to be largely reusable for other similar
devices, so I've ended up changing it to act as an interface
between a device driver and XVideo. This is somewhat similar
to SunxiG2D, which is used as an abstraction layer by multiple
hardware drivers.

Note: This commit is for gathering feedback, please don't
merge it in your main branches since it breaks stuff.

Once we agree on a design, I'm willing to port the Sunxi driver
to use this interface. Note, however, that I don't have any
hardware set up for testing it, so it would be nice if someone
else offered to test it or maybe port it themselves.

In terms of functionally there are two things I've changed:
- I've replaced the clipping stuff with a new function, which clips
  the drw area to the visible screen so that no content is attempted
  to be rendered off-screen, and at the same time it sets up margins
  and offsets for the src area so that only the correct content is
  rendered in the visible portion of the drw area. As far as I can
  tell, the results from xf86XVClipVideoHelper were not actually used(?)
- The driver struct has a flags field which can be used to control
  various features. The only flag I'm introducing is for enabling
  or disabling double (well, technically multiple) buffering. I need
  this feature for RK3188 since from my tests I can't change the
  frame pointer fast enough for video. I could also work around it using
  a custom copy_buffer(), but I think that would be quite dirty. :)

I would appreciate a relatively quick discussion so that I can avoid
publishing code depending on this draft. Thank you
