### PR TITLE
Allow negative hardware cursor position on sunxi

### DIFF
--- a/src/sunxi_disp.c
+++ b/src/sunxi_disp.c
@@ -228,10 +228,6 @@ int sunxi_hw_cursor_set_position(sunxi_disp_t *ctx, int x, int y)
     __disp_pos_t pos = { x, y };
     tmp[0] = ctx->fb_id;
     tmp[1] = (uintptr_t)&pos;
-    if (pos.x < 0)
-        pos.x = 0;
-    if (pos.y < 0)
-        pos.y = 0;
     result = ioctl(ctx->fd_disp, DISP_CMD_HWC_SET_POS, &tmp);
     if (result >= 0) {
         ctx->cursor_x = pos.x;


### PR DESCRIPTION
With linux-sunxi/linux-sunxi@2aeb0e920 it is now possible to use negative hardware cursor coordinates.
Tested only on sun4i and sun7i, but I don't see any obvious reason why it shouldn't work on sun5i too.
