### PR TITLE
sunxi_x_g2d: drop unused dri2 include

### DIFF
--- a/src/sunxi_x_g2d.c
+++ b/src/sunxi_x_g2d.c
@@ -31,7 +31,6 @@
 #include "xf86_OSproc.h"
 #include "xf86.h"
 #include "xf86drm.h"
-#include "dri2.h"
 #include "damage.h"
 #include "fb.h"
 #include "gcstruct.h"


### PR DESCRIPTION
The driver doesn't use DRI for anything.

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>