### PR TITLE
Fix build by using #ifdef instead of #if in fbdev.c

### DIFF
--- a/src/fbdev.c
+++ b/src/fbdev.c
@@ -1037,7 +1037,7 @@ FBDevScreenInit(SCREEN_INIT_ARGS_DECL)
 	fPtr->CloseScreen = pScreen->CloseScreen;
 	pScreen->CloseScreen = FBDevCloseScreen;
 
-#if XV
+#ifdef XV
 	fPtr->SunxiVideo_private = NULL;
 	if (xf86ReturnOptValBool(fPtr->Options, OPTION_XV_OVERLAY, TRUE) &&
 	fPtr->sunxi_disp_private) {
@@ -1127,7 +1127,7 @@ FBDevCloseScreen(CLOSE_SCREEN_ARGS_DECL)
 	    fPtr->SunxiDispHardwareCursor_private = NULL;
 	}
 
-#if XV
+#ifdef XV
 	if (fPtr->SunxiVideo_private) {
 	    SunxiVideo_Close(pScreen);
 	    free(fPtr->SunxiVideo_private);


### PR DESCRIPTION
Hi!

I was trying to build fbturbo on Void Linux (gcc 8.2.0) but ran into

```
fbdev.c:1040:7: error: #if with no expression
 #if XV
       ^
fbdev.c: In function 'FBDevCloseScreen':
fbdev.c:1129:7: error: #if with no expression
 #if XV
       ^
```

This can be fixed by changing `#if` into `#ifdef`.