### PR TITLE
backports from xf86-video-fbdev

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -32,6 +32,7 @@ fbturbo_drv_la_SOURCES = \
          compat-api.h \
          uthash.h \
          arm_asm.S \
+         aarch64_asm.S \
          cpuinfo.c \
          cpuinfo.h \
          cpu_backend.c \

--- a/src/aarch64_asm.S
+++ b/src/aarch64_asm.S
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2016 Siarhei Siamashka <siarhei.siamashka@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+/* Prevent the stack from becoming executable */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif
+
+#ifdef __aarch64__
+
+    .cpu cortex-a53+fp+simd
+    .text
+    .align 2
+
+/******************************************************************************/
+
+.macro asm_function function_name
+    .global \function_name
+#ifdef __ELF__
+    .hidden \function_name
+    .type \function_name, %function
+#endif
+.func \function_name
+\function_name:
+.endm
+
+/******************************************************************************/
+
+asm_function aligned_fetch_fbmem_to_scratch_neon
+    SIZE        .req x0
+    DST         .req x1
+    SRC         .req x2
+
+    subs        SIZE, SIZE, #128
+    blt         1f
+0:
+    ldp         q0,  q1, [SRC, #(0 * 32)]
+    ldp         q2,  q3, [SRC, #(1 * 32)]
+    stp         q0,  q1, [DST, #(0 * 32)]
+    stp         q2,  q3, [DST, #(1 * 32)]
+    ldp         q0,  q1, [SRC, #(2 * 32)]
+    ldp         q2,  q3, [SRC, #(3 * 32)]
+    add         SRC, SRC, #128
+    stp         q0,  q1, [DST, #(2 * 32)]
+    stp         q2,  q3, [DST, #(3 * 32)]
+    add         DST, DST, #128
+    subs        SIZE, SIZE, #128
+    bge         0b
+1:
+    tst         SIZE, #64
+    beq         1f
+    ldp         q0,  q1, [SRC, #(0 * 32)]
+    ldp         q2,  q3, [SRC, #(1 * 32)]
+    add         SRC, SRC, #64
+    stp         q0,  q1, [DST, #(0 * 32)]
+    stp         q2,  q3, [DST, #(1 * 32)]
+    add         DST, DST, #64
+1:
+    tst         SIZE, #32
+    beq         1f
+    ldp         q0,  q1, [SRC, #(0 * 32)]
+    add         SRC, SRC, #32
+    stp         q0,  q1, [DST, #(0 * 32)]
+    add         DST, DST, #32
+1:
+    tst         SIZE, #31
+    beq         1f
+    ldp         q0, q1, [SRC]
+    stp         q0, q1, [DST]
+1:
+    ret
+
+    .unreq      SIZE
+    .unreq      DST
+    .unreq      SRC
+.endfunc
+
+#endif

--- a/src/backing_store_tuner.c
+++ b/src/backing_store_tuner.c
@@ -109,7 +109,7 @@ xPostValidateTree(WindowPtr pWin, WindowPtr pLayerWin, VTKind kind)
     private->PostValidateTreeNestingLevel++;
 
     /* Disable backing store for the focus window */
-    if (!private->ForceBackingStore && focusWin->backStorage) {
+    if (!private->ForceBackingStore && focusWin->backingStore) {
         DebugMsg("Disable backing store for the focus window 0x%x\n",
                  (unsigned int)focusWin->drawable.id);
         pScreen->backingStoreSupport = Always;
@@ -125,7 +125,7 @@ xPostValidateTree(WindowPtr pWin, WindowPtr pLayerWin, VTKind kind)
     /* And enable backing store for all the other children of root */
     curWin = pScreen->root->firstChild;
     while (curWin) {
-        if (!curWin->backStorage && (private->ForceBackingStore ||
+        if (!curWin->backingStore && (private->ForceBackingStore ||
                                      curWin != focusWin)) {
             DebugMsg("Enable backing store for window 0x%x\n",
                      (unsigned int)curWin->drawable.id);
@@ -158,7 +158,7 @@ xReparentWindow(WindowPtr pWin, WindowPtr pPriorParent)
     }
 
     /* We only want backing store set for direct children of root */
-    if (pPriorParent == pScreen->root && pWin->backStorage) {
+    if (pPriorParent == pScreen->root && pWin->backingStore) {
         DebugMsg("Reparent window 0x%x from root, disabling backing store\n",
                  (unsigned int)pWin->drawable.id);
         pScreen->backingStoreSupport = Always;

--- a/src/fbdev.c
+++ b/src/fbdev.c
@@ -884,7 +884,7 @@ FBDevScreenInit(SCREEN_INIT_ARGS_DECL)
 	 */
 	useBackingStore = xf86ReturnOptValBool(fPtr->Options, OPTION_USE_BS,
 	                                       !fPtr->shadowFB);
-#ifndef __arm__
+#if !(defined(__arm__) || defined(__aarch64__))
 	/*
 	 * right now we can only make "smart" decisions on ARM hardware,
 	 * everything else (for example x86) would take a performance hit

--- a/src/fbdev.c
+++ b/src/fbdev.c
@@ -675,9 +675,13 @@ FBDevCreateScreenResources(ScreenPtr pScreen)
 
     pPixmap = pScreen->GetScreenPixmap(pScreen);
 
-    if (fPtr->rotate)
+#if 0    
+    if (fPtr->shadow24)
+        update = fbdevUpdate32to24;
+    else if (fPtr->rotate)
         update = fbdevUpdateRotatePacked;
     else
+#endif
         update = fbdevUpdatePacked;
 
     if (!shadowAdd(pScreen, pPixmap, update, 

--- a/src/fbdev.c
+++ b/src/fbdev.c
@@ -675,9 +675,7 @@ FBDevCreateScreenResources(ScreenPtr pScreen)
 
     pPixmap = pScreen->GetScreenPixmap(pScreen);
 
-    if (fPtr->shadow24)
-        update = fbdevUpdate32to24;
-    else if (fPtr->rotate)
+    if (fPtr->rotate)
         update = fbdevUpdateRotatePacked;
     else
         update = fbdevUpdatePacked;

--- a/src/fbdev.c
+++ b/src/fbdev.c
@@ -177,7 +177,6 @@ typedef enum {
 	OPTION_USE_BS,
 	OPTION_FORCE_BS,
 	OPTION_XV_OVERLAY,
-	OPTION_DEBUG
 } FBDevOpts;
 
 static const OptionInfoRec FBDevOptions[] = {

--- a/src/fbdev_priv.h
+++ b/src/fbdev_priv.h
@@ -44,6 +44,7 @@ typedef struct {
 	int				lineLength;
 	int				rotate;
 	Bool				shadowFB;
+	Bool				shadow24;
 	void				*shadow;
 	CloseScreenProcPtr		CloseScreen;
 	CreateScreenResourcesProcPtr	CreateScreenResources;


### PR DESCRIPTION
fbdev.c backports from xf86-video-fbdev 0.5.0 to make it compile against recent versions of Xorg